### PR TITLE
Add ">=" In Nim Version

### DIFF
--- a/ws.nimble
+++ b/ws.nimble
@@ -9,4 +9,4 @@ srcDir        = "src"
 
 # Dependencies
 
-requires "nim > 1.0.0"
+requires "nim >= 1.0.0"


### PR DESCRIPTION
I Add this because if ws used as a dependency in a library (e.g Servy) nimble throughs an error: 

``` Error: Unsatisfied dependency: nim (> 1.0.0) ```